### PR TITLE
Conflict with gems that loads ActiveSupport

### DIFF
--- a/lib/caplock.rb
+++ b/lib/caplock.rb
@@ -6,7 +6,7 @@ module Capistrano
     # Returns Boolean indicating the result of +filetest+ on +full_path+ on the server, evaluated by shell on 
     # the server (usually bash or something roughly compatible).
     def remote_filetest_passes?(filetest, full_path)
-      'true' ==  capture("if [ #{filetest} #{full_path} ]; then echo 'true'; fi").strip
+      'true' ==  top.capture("if [ #{filetest} #{full_path} ]; then echo 'true'; fi").strip
     end
   
     # Checks if a symlink exists on the remote machine.
@@ -23,7 +23,7 @@ module Capistrano
     # is equivalent to content by checking whether or not the MD5 of the remote content is the same as the
     # MD5 of the String in +content+.
     def remote_file_content_same_as?(full_path, content)
-      Digest::MD5.hexdigest(content) == capture("md5sum #{full_path} | awk '{ print $1 }'").strip
+      Digest::MD5.hexdigest(content) == top.capture("md5sum #{full_path} | awk '{ print $1 }'").strip
     end
 
     # Returns Boolean indicating whether the remote file is present and has the same contents as


### PR DESCRIPTION
When I use caplock with another gem which load ActiveSupport (like the capistrano_mailer which loads active_mailer), it causes a conflict with Capistrano's capture method as described here:
https://github.com/capistrano/capistrano/issues/168

I asked in the #capistrano freenode IRC channel how I could fix this and I as told to use top.capture rather than simply capture.  With this change, there is no longer any conflicts.

Here is the error I get without this change when I use caplock with capistrano_mailer:

```
  * 2012-10-31 12:44:41 executing `lock:check'
/home/user/.rvm/gems/ruby-1.9.3-p194/gems/activesupport-3.2.8/lib/active_support/core_ext/kernel/reporting.rb:75:in `eval': (eval):1: syntax error, unexpected tREGEXP_BEG, expecting keyword_do or '{' or '(' (SyntaxError)
$if [ -e /var/www/www.example.co...
          ^
(eval):1: unknown regexp options - hc
(eval):1: syntax error, unexpected ']', expecting $end
...ww.example.com/cap.lock ]; then echo 'true'; fi = IF [...
...                               ^
        from /home/user/.rvm/gems/ruby-1.9.3-p194/gems/activesupport-3.2.8/lib/active_support/core_ext/kernel/reporting.rb:75:in `ensure in capture'
        from /home/user/.rvm/gems/ruby-1.9.3-p194/gems/activesupport-3.2.8/lib/active_support/core_ext/kernel/reporting.rb:75:in `capture'
        from /home/user/.rvm/gems/ruby-1.9.3-p194/gems/caplock-0.2.0/lib/caplock.rb:9:in `remote_filetest_passes?'
        from /home/user/.rvm/gems/ruby-1.9.3-p194/gems/caplock-0.2.0/lib/caplock.rb:19:in `remote_file_exists?'
```

I ran the unit tests and they all pass after this change.
I tried adding a new test but I did not know how to do that without adding active_support as a dependencies, which does not seem right.

Let me know what you think.
