### PR TITLE
Improved locking: use raise instead of abort, create lock before update_...

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,6 +15,10 @@ Include in your Capfile
 Define the name of your lock file in your deploy.rb
    set :lockfile, "my.lock" # defaults to "cap.lock"
 
+The `lock:check` task is executed automatically before `deploy:update_code` (i.e. before deploy).
+If you have overridden the default deploy task, you may need to add the task with:
+   before "deploy", "lock:check"
+
 If the lockfile becomes stale (because you interrupted the deployment with CTRL-C for example)
    cap lock:release  # or "cap production lock:release" with multistage
 

--- a/test/test_caplock.rb
+++ b/test/test_caplock.rb
@@ -1,13 +1,44 @@
 require 'helper'
 
+class StubLogger
+  def close ; end
+  def log(level, message, line_prefix=nil) ; end
+  def important(message, line_prefix=nil) ; end
+  def info(message, line_prefix=nil) ; end
+  def debug(message, line_prefix=nil) ; end
+  def trace(message, line_prefix=nil); end
+  def format(message, color, style, nl = "\n") ; end
+end
+
 class TestCaplock < Test::Unit::TestCase
+  class TestCaplockError < RuntimeError ; end
+
   def setup
+    @update_code_raise = false;
     @config = Capistrano::Configuration.new
+    @config.load do
+      namespace :deploy do
+        task :default do
+          transaction do
+            update_code
+          end
+        end
+        task :update_code do
+          raise TestCaplockError, "update_code simulated exception" if caplock_update_code_raise
+        end
+      end
+    end
+    @config.logger = StubLogger.new
+    #@config.logger = Capistrano::Logger.new :level => Capistrano::Logger::MAX_LEVEL
     Capistrano::Caplock.load_into(@config)
     @config.set :deploy_to, "/tmp"
+    @config.set :caplock_update_code_raise, false
     @config.role :app, "localhost"
+
+    # ensure clean test
+    File.unlink("/tmp/cap.lock") if File.exists?("/tmp/cap.lock")
   end
-  
+
   should "use default lockfile name 'cap.lock'" do
     assert_equal @config.lockfile, 'cap.lock'
   end
@@ -33,15 +64,35 @@ class TestCaplock < Test::Unit::TestCase
      assert_nil @config.lock.check
   end
   
-  # FIXME: need to find a way to test 'abort'
   should "check for lock and abort" do
      assert_nil @config.lock.create
-     #assert_raises SystemExit, @config.lock.check
+     assert_raises(Capistrano::Caplock::LockedDeployError) { @config.lock.check }
   end
   
   should "check if remote file exists" do
      @config.set :lockfile, 'test.lock'
      assert_nil @config.lock.create
      assert @config.caplock.remote_file_exists?("/tmp/test.lock")
+  end
+
+  should "remove lock on rollback" do
+    @config.set :caplock_update_code_raise, true
+    assert_raises(TestCaplockError) { @config.deploy.default }
+    assert_nil @config.lock.check
+  end
+
+  should "not remove lock owned by other process" do
+    File.open("/tmp/cap.lock", "w") { |file| file.write("Simulate cap.lock from another deploy process") }
+    assert File.exists?("/tmp/cap.lock")
+    assert_raises(Capistrano::Caplock::LockedDeployError) { @config.deploy.default }
+    # rollback should not have removed the file, so it is still locked
+    assert_raises(Capistrano::Caplock::LockedDeployError) { @config.lock.check }
+  end
+
+  should "remove lock owned by other process on manual release" do
+    File.open("/tmp/cap.lock", "w") { |file| file.write("Simulate cap.lock from another deploy process") }
+    assert File.exists?("/tmp/cap.lock")
+    assert_nil @config.lock.release
+    assert_nil @config.lock.check
   end
 end


### PR DESCRIPTION
...code

Hi!
    I've made a few changes to the locking/unlocking task so that it is very rare to have a stale lock file. I know that Capistrano 2 is now considered legacy code, but I think that a 0.3.0 version will not hurt. :)

The main changes is that the code is not triggered before deploy, but before update_code, which is actually inside the deploy task. By doing so, (almost) nothing change in the deploy flow, but the lock:check task is called inside a transaction, which enable the use of exceptions and the on_rollback trigger.

So the improvements are:
- Backward compatible (some fancy configuration may need tweaking though);
- On failure/ctrl-c/... on_rollback ensure proper cleanup of lock file;
- avoid abort function, use LockedDeployError exception instead.

I've added all the required test case and removed the FIXME you left behind. :)

What do you think about it?
